### PR TITLE
used pop method instead of del to remove key from dictionary.

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ async def generate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     chat_id = update.effective_chat.id
     if chat_id in chat_states:
-        del chat_states[chat_id]
+        chat_states.pop(chat_id, None)
     await update.message.reply_text('Generation canceled. 🚫 You can start again with /generate.')
 
 # Handler for button presses


### PR DESCRIPTION
Instead of using del to remove the chat state entry for the given chat_id, I used chat_states.pop(chat_id, None). This method removes the specified key from the dictionary if it exists, and if not, it returns None.

Why:

Using dict.pop(key, None) simplifies the code and ensures that if the key is not present in the dictionary, it doesn't raise a KeyError. This is safer and more Pythonic compared to using del, especially when dealing with potential key errors. It provides a cleaner way to remove items from a dictionary, making the code more readable and maintainable.